### PR TITLE
7.0.0-canary

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,6 @@ module.exports = require('@hugsmidjan/hxmstyle')({
     node: true,
   },
   parserOptions: {
-    ecmaVersion: 2018, // fantasy
+    ecmaVersion: 2018,
   },
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ... <!-- Add new lines here. -->
 - **BREAKING** feat: Drop support for Stylus
+- feat: Relax `no-irregular-whitespace` to `skipRegExps:true`
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   to hide plugins from a consuming project's `pkg.dependencies`
 - feat: Update all dependencies to latest versions
 - feat: Relax `no-irregular-whitespace` to `skipRegExps:true`
+- fix: Broken auto-detection of `sass` as dependency in project
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- **BREAKING** feat: Drop support for Stylus
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - ... <!-- Add new lines here. -->
 - **BREAKING** feat: Drop support for Stylus
+- feat: Support a `extendsFirst` array in `.eslintrc.js` — to better control
+  the addition of custom presets
 - feat: Use
   [@rushstack/eslint-patch](https://www.npmjs.com/package/@rushstack/eslint-patch)
   to hide plugins from a consuming project's `pkg.dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 6.4.1
 
 _2023-02-27_
+
 - fix: Update stylelint
 
 ## 6.4.0
@@ -16,12 +17,7 @@ _2023-02-16_
 - feat: Update all dependencies to latest versions
 - fix: Update stylelint prop order
 
-## 6.3.1
-_2022-09-12_
-
-- fix: Typo
-
-## 6.3.0
+## 6.3.0 – 6.3.1
 
 _2022-09-12_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - ... <!-- Add new lines here. -->
 - **BREAKING** feat: Drop support for Stylus
+- feat: Use
+  [@rushstack/eslint-patch](https://www.npmjs.com/package/@rushstack/eslint-patch)
+  to hide plugins from a consuming project's `pkg.dependencies`
+- feat: Update all dependencies to latest versions
 - feat: Relax `no-irregular-whitespace` to `skipRegExps:true`
 
 ## 6.4.1

--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ plugins and add/remove optional preset bundles.
 
 If the installer detects that your project is using TypeScript, it installs
 the relevant TS plugins and a minimal `tsconfig.json` file with
-`compilerOptions.strict: true`. (As if you'd run `hxmstyle --typescript`)
-
-If the installer detects that your project is using stylus, it will install
-`stylint` and a very opinionated [`.stylintrc`](starters/stylintrc.js) file.
-(Just like if you'd run `hxmstyle --stylus`)
+`compilerOptions.strict: true`. (As if you'd run `hxmus --typescript`)
 
 Similarily if `react` (or `preact` or `inferno`) is detected, a react plugin
 is installed. (As if you'd run `hxmstyle --react`)
@@ -39,22 +35,21 @@ Both the `npx` installer and the local CLI command take one or more optional
 flags.
 
 ```
-hxmstyle --react --stylus --scss --typescript
+hxmstyle --typescript --react --scss
 ```
 
 is the same as
 
 ```
-hxmstyle --react
-hxmstyle --stylus
-hxmstyle --scss
 hxmstyle --typescript
+hxmstyle --react
+hxmstyle --scss
 ```
 
 To turn off one or more options pass `false` as a value, like so:
 
 ```
-hxmstyle --react=false --stylus=false --scss=false --typescript=false
+hxmstyle --react=false --scss=false --typescript=false
 ```
 
 ...or edit your `package.json`'s `hxmstyle.options` field and set the
@@ -124,8 +119,6 @@ Add these plugins:
 - [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig)
 - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
   – for files other than JavaScript/TypeScript (Markdown, JSON, HTML, etc.)
-- [Stylint](https://marketplace.visualstudio.com/items?itemName=HaaLeo.vscode-stylint)
-  – if you're writing Stylus code
 - [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
   – if you're writing scss code
   

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ the relevant TS plugins and a minimal `tsconfig.json` file with
 Similarily if `react` (or `preact` or `inferno`) is detected, a react plugin
 is installed. (As if you'd run `hxmstyle --react`)
 
-And if `scss` is detected, stylelint plugin is installed. (As if you'd run `hxmstyle --scss`)
+And if `scss` is detected, stylelint plugin is installed. (As if you'd run
+`hxmstyle --scss`)
 
 ### Install options
 
@@ -73,6 +74,13 @@ neccessary changes to `.eslintrc.js`, `.prettierrc.js` and/or `.stylintrc`.
 
 If one of your `.*rc` files goes missing or gets corrupted, you can find fresh
 ones [in the "starters" directory](starters/).
+
+Framework/library-specific config presets can be added to your project's
+`.eslintrc.js` file via the `extends` property. These values are loaded
+_after_ the `hxmstyle` rules.
+
+However, in some cases you may want to set them to a lower priority by adding
+them in via the `extendsFirst` array.
 
 ## Removing plugins
 
@@ -121,7 +129,6 @@ Add these plugins:
   – for files other than JavaScript/TypeScript (Markdown, JSON, HTML, etc.)
 - [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
   – if you're writing scss code
-  
 
 ...and these settings:
 

--- a/bin/installer.js
+++ b/bin/installer.js
@@ -64,7 +64,7 @@ const args = Object.assign(
 
 // auto-detect options based on already installed deps
 {
-  if (args.scss == null && projectDeps.scss) {
+  if (args.scss == null && projectDeps.sass) {
     console.info('scss detected.');
     args.scss = true;
   }

--- a/bin/installer.js
+++ b/bin/installer.js
@@ -52,7 +52,6 @@ const cleanOptions = (options) => {
 
 const supportedArgs = {
   typescript: true,
-  stylus: true,
   scss: true,
   react: true,
 };
@@ -188,31 +187,6 @@ if (args.typescript) {
     fs.writeFileSync(editorcfgPath, configRules);
     console.info('- Done.');
   }
-}
-
-// Update .stylintrc
-if (args.stylus) {
-  const stylintrcPath = projectPath + '.stylintrc';
-  const stylintRules = require(hxmstylePath + 'starters/stylintrc.js');
-  const hasStylintrc = fs.existsSync(stylintrcPath);
-  if (hasStylintrc) {
-    const hxmStyleMarker = '__hxmstyle__';
-    const projectSpecificMarker = '__project_specific_rules__';
-    const projectRules = JSON.parse(fs.readFileSync(stylintrcPath));
-    // Maintain anything below the projectSpecificMarker in projectRules
-    let searchingForMarker = hxmStyleMarker in projectRules; // If no hxmStyleMarker is found - assume every rule is project-specific
-    Object.entries(projectRules).forEach(([key, rule]) => {
-      if (searchingForMarker) {
-        searchingForMarker = key !== projectSpecificMarker;
-      } else if (rule !== stylintRules[key]) {
-        delete stylintRules[key]; // delete from Object.keys() array
-        stylintRules[key] = rule; // Re-insert at end of Object.keys()
-      }
-    });
-  }
-  console.info(hasStylintrc ? 'Updating .stylintrc' : 'Adding .stylintrc');
-  fs.writeFileSync(stylintrcPath, JSON.stringify(stylintRules, null, '\t') + '\n');
-  console.info('- Done.');
 }
 
 // Update .stylelintrc.json

--- a/bin/installer.js
+++ b/bin/installer.js
@@ -52,22 +52,20 @@ const cleanOptions = (options) => {
   return options;
 };
 
-const supportedArgs = {
+const args = parseArgs(process.argv.slice(2), {
   typescript: true,
-  scss: true,
   react: true,
-};
-const args = Object.assign(
-  cleanOptions(lastSettings.options),
-  parseArgs(process.argv.slice(2), supportedArgs)
-);
+  scss: true,
+});
 
 // auto-detect options based on already installed deps
 {
-  if (args.scss == null && projectDeps.sass) {
+  const projectHasSCSS = () => projectDeps.sass;
+  if (args.scss == null && projectHasSCSS()) {
     console.info('scss detected.');
     args.scss = true;
   }
+
   const projectHasReact = () =>
     projectDeps.react || projectDeps.preact || projectDeps.inferno;
   if (args.react == null && projectHasReact()) {

--- a/bin/installer.js
+++ b/bin/installer.js
@@ -16,6 +16,8 @@ const lastSettings = projectPkg.hxmstyle || {};
 const hxmstylePath = path.parse(require.resolve('@hugsmidjan/hxmstyle')).dir + '/';
 const hxmstylePkg = require(hxmstylePath + 'package.json');
 
+// ---------------------------------------------------------------------------
+
 const parseArgs = (argv, supportedArgs) => {
   const args = {};
   let name = '';
@@ -60,68 +62,76 @@ const args = Object.assign(
   parseArgs(process.argv.slice(2), supportedArgs)
 );
 
-// Auto-detect if scss, stylus or react are installed in the project
-const projectHasStylus = () => {
-  return (
-    projectDeps.stylus ||
-    (projectDeps.hxmgulp && fs.existsSync(projectPath + 'node_modules/stylus'))
-  );
+// auto-detect options based on already installed deps
+{
+  if (args.scss == null && projectDeps.scss) {
+    console.info('scss detected.');
+    args.scss = true;
+  }
+  const projectHasReact = () =>
+    projectDeps.react || projectDeps.preact || projectDeps.inferno;
+  if (args.react == null && projectHasReact()) {
+    const reactLike = projectDeps.react
+      ? 'React'
+      : projectDeps.preact
+      ? 'Preact'
+      : 'Inferno';
+    console.info(reactLike + ' detected.');
+    args.react = true;
+  }
+
+  const projectHasTypeScript = () => projectDeps.typescript;
+  if (args.typescript == null && projectHasTypeScript()) {
+    console.info('TypeScript detected.');
+    args.typescript = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+const installDeps = {
+  ...hxmstylePkg.peerDependencies,
 };
-
-if (args.stylus == null && projectHasStylus()) {
-  console.info('Stylus detected.');
-  args.stylus = true;
-}
-
-if (args.scss == null && projectDeps.scss) {
-  console.info('scss detected.');
-  args.scss = true;
-}
-
-const projectHasReact = () => {
-  return projectDeps.react || projectDeps.preact || projectDeps.inferno;
-};
-
-if (args.react == null && projectHasReact()) {
-  const reactLike = projectDeps.react
-    ? 'React'
-    : projectDeps.preact
-    ? 'Preact'
-    : 'Inferno';
-  console.info(reactLike + ' detected.');
-  args.react = true;
-}
-
-const projectHasTypeScript = () => projectDeps.typescript;
-
-if (args.typescript == null && projectHasTypeScript()) {
-  console.info('TypeScript detected.');
-  args.typescript = true;
-}
-
-const installDeps = hxmstylePkg.peerDependencies;
+Object.entries(hxmstylePkg.peerDependenciesMeta).forEach(([key, meta]) => {
+  // Skip installing "optional" peerDependences, unless they're
+  // explicitly flagged in `args` AND missing from projectPkg
+  if (
+    meta.optional &&
+    (!args[key] || projectDeps[key] || projectPkg.peerDependencies[key])
+  ) {
+    delete installDeps[key];
+  }
+});
+// Keeping track of the names of dependences that are installed by hxmstyle
+// (Currently these are only deps related to `args.scss`.)
+const managedDeps = [];
 Object.entries(hxmstylePkg.optionals).forEach(([option, deps]) => {
   if (args[option]) {
     Object.entries(deps).forEach(([name, version]) => {
       installDeps[name] = version;
+      managedDeps.push(name);
     });
   }
 });
 
 // install/upgrade plugins
-const installs = Object.entries(installDeps).map(
-  ([name, version]) => name + '@' + version
-);
-if (!projectDeps['@hugsmidjan/hxmstyle']) {
-  installs.push('@hugsmidjan/hxmstyle@^' + hxmstylePkg.version);
+{
+  const installs = Object.entries(installDeps).map(
+    ([name, version]) => name + '@' + version
+  );
+  if (!projectDeps['@hugsmidjan/hxmstyle']) {
+    installs.push('@hugsmidjan/hxmstyle@^' + hxmstylePkg.version);
+  }
+  if (installs.length) {
+    console.info('Adding/upgrading dependencies:\n', installs);
+    const useYarn = !!exec('which yarn') && fs.existsSync(projectPath + 'yarn.lock');
+    const installCmd = useYarn ? 'yarn add --dev ' : 'npm install --save-dev ';
+    exec(installCmd + installs.join(' '));
+    console.info('- Done.');
+  }
 }
-if (installs.length) {
-  console.info('Adding/upgrading dependencies:\n', installs);
-  const useYarn = !!exec('which yarn') && fs.existsSync(projectPath + 'yarn.lock');
-  const installCmd = useYarn ? 'yarn add --dev ' : 'npm install --save-dev ';
-  exec(installCmd + installs.join(' '));
-  console.info('- Done.');
-}
+
+// ---------------------------------------------------------------------------
 
 // Create default .eslintrc.js file
 if (!fs.existsSync(projectPath + '.eslintrc.js')) {
@@ -129,7 +139,7 @@ if (!fs.existsSync(projectPath + '.eslintrc.js')) {
   exec('cp ' + hxmstylePath + 'starters/eslintrc.js .eslintrc.js');
   console.info('- Done.');
 }
-// Create default .preddierrc.js file
+// Create default .prettierrc.js file
 if (!fs.existsSync(projectPath + '.prettierrc.js')) {
   console.info('Creating .prettierrc.js');
   exec('cp ' + hxmstylePath + 'starters/prettierrc.js .prettierrc.js');
@@ -164,7 +174,7 @@ if (args.typescript) {
   }
 }
 
-// Update .editorconfig
+// Update/manage .editorconfig
 {
   const editorcfgPath = projectPath + '.editorconfig';
   let configRules = fs.readFileSync(hxmstylePath + 'starters/editorconfig.cfg');
@@ -201,17 +211,30 @@ if (args.scss) {
   console.info('- Done.');
 }
 
+// ---------------------------------------------------------------------------
+
 // Write settings to package.json
-projectPkg = JSON.parse(fs.readFileSync(projectPkgPath)); // Re-read package.json since its content may have changed.
-projectPkg.hxmstyle = {
-  options: args,
-  dependenciesAdded: Object.keys(installDeps).sort(),
-};
-fs.writeFileSync(projectPkgPath, JSON.stringify(projectPkg, null, '\t') + '\n');
+{
+  const hasOptions = !!Object.keys(args).length;
+  const hasDepsAdded = !!managedDeps.length;
+  if (hasOptions || hasDepsAdded) {
+    const hxmstyle = {};
+    if (hasOptions) {
+      hxmstyle.options = args;
+    }
+    if (hasDepsAdded) {
+      hxmstyle.dependenciesAdded = managedDeps.sort();
+    }
+    // Re-read `package.json` since its contents may have changed due to installs.
+    projectPkg = JSON.parse(fs.readFileSync(projectPkgPath));
+    projectPkg.hxmstyle = hxmstyle;
+    fs.writeFileSync(projectPkgPath, JSON.stringify(projectPkg, null, '\t') + '\n');
+  }
+}
 
 // Suggest adding a format script to package.json
 if (!projectPkg.scripts || !projectPkg.scripts.format) {
-  const jsExts = args.typescript ? '{js,ts,tsx}' : 'js';
+  const jsExts = args.typescript ? '{js,ts,tsx}' : 'js,jsx';
   console.info(
     [
       'Consider adding a "format" npm script to your `package.json`',
@@ -222,7 +245,7 @@ if (!projectPkg.scripts || !projectPkg.scripts.format) {
         jsExts +
         '\\" \\"_src/**/*.' +
         jsExts +
-        '\\"  &&  prettier --write \\"*.json\\""',
+        '\\"  &&  prettier --write  \\"*.md\\" \\"*.json\\""',
       '    },',
       '',
       'More info: https://github.com/hugsmidjan/hxmstyle/blob/master/README.md#example-npm-scripts',

--- a/configs/core.js
+++ b/configs/core.js
@@ -94,7 +94,8 @@ module.exports = {
 		'no-irregular-whitespace': ['error', {
 			"skipStrings": true, // Default
 			"skipComments": true,
-			"skipTemplates": true
+			"skipTemplates": true,
+			"skipRegExps": true
 		}],
 
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,15 @@ module.exports = (userCfg = {}, options) => {
       config.extends.push(rulePackageName);
     });
   }
+  // Merge in the user's "extendsFirst" BEFORE other extends
+  // to put them at a lower priority than the hxmstyle rules.
+  if (userCfg.extendsFirst) {
+    userCfg.extendsFirst.forEach((rulePackageName) => {
+      config.extends.unshift(rulePackageName);
+    });
+    // cleanup
+    delete userCfg.extendsFirst;
+  }
 
   return config;
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+/**
+ * @see https://github.com/eslint/eslint/issues/3458
+ * @see https://www.npmjs.com/package/@rushstack/eslint-patch
+ */
+require('@rushstack/eslint-patch/modern-module-resolution');
+
 const path = require('path');
 
 let _pkg;

--- a/index.js
+++ b/index.js
@@ -4,12 +4,7 @@ let _pkg;
 const getProjectPkg = () => _pkg || require(process.cwd() + '/package.json');
 
 const rulesetPath = path.parse(require.resolve('@hugsmidjan/hxmstyle')).dir + '/configs/';
-const extendModules = [
-  'core',
-  'typescript',
-  'react',
-  'fantasy', // deprecated as of v0.3.0
-];
+const extendModules = ['core', 'typescript', 'react'];
 
 const getBaseExtends = (opts) => {
   const _extends = [rulesetPath + 'core.js'];

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
       "eslint-plugin-react": "^7.32.2",
       "eslint-plugin-react-hooks": "^4.6.0"
     },
-    "stylus": {
-      "stylint": "^2.0.0"
-    },
     "scss": {
       "stylelint": "^15.1.0",
       "stylelint-config-recommended-scss": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
   "repository": "git@github.com:hugsmidjan/hxmstyle.git",
   "author": "Hugsmiðjan ehf (https://www.hugsmidjan.is)",
   "contributors": [
-    "Már Örlygsson <mar.nospam@anomy.net> (http://mar.anomy.net)"
+    "Már Örlygsson <mar.nospam@anomy.net>",
+    "Valur Sverrison <value@hugsmidjan.is>",
+    "Mikael Elí Stefánsson <mikaeleli221@gmail.com>"
   ],
   "license": "GPL-2.0-or-later",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "author": "Hugsmiðjan ehf (https://www.hugsmidjan.is)",
   "contributors": [
     "Már Örlygsson <mar.nospam@anomy.net>",
-    "Valur Sverrison <value@hugsmidjan.is>",
+    "Valur Sverrison <valur@hugsmidjan.is>",
     "Mikael Elí Stefánsson <mikaeleli221@gmail.com>"
   ],
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hugsmidjan/hxmstyle",
   "description": "One annoying style to rule them all...",
-  "version": "6.4.1",
+  "version": "7.0.0-canary",
   "main": "index.js",
   "bin": {
     "hxmstyle": "bin/installer.js"

--- a/package.json
+++ b/package.json
@@ -13,28 +13,37 @@
     "dogfood": "yarn upgrade @hugsmidjan/hxmstyle && hxmstyle && yarn run format",
     "format": "eslint --fix  \"*.js\" \"**/*.js\"  &&  prettier --write --loglevel=error  \"*.md\" \"*.json\""
   },
-  "peerDependencies": {
-    "eslint": "^8.34.0",
-    "eslint-config-prettier": "^8.6.0",
+  "dependencies": {
+    "@rushstack/eslint-patch": "^1.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.52.0",
+    "@typescript-eslint/parser": "^5.52.0",
+    "eslint-config-prettier": "^8.7.0",
+    "eslint-plugin-deprecation": "^1.3.3",
     "eslint-plugin-destructure-depth": "^1.0.3",
     "eslint-plugin-destructuring": "^2.2.1",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "eslint-plugin-total-functions": "^6.0.0",
-    "eslint-plugin-unused-imports": "^2.0.0",
-    "prettier": "^2.8.4"
+    "eslint-plugin-total-functions": "^6.2.0",
+    "eslint-plugin-unused-imports": "^2.0.0"
   },
-  "optionals": {
+  "peerDependencies": {
+    "eslint": "^8.35.0",
+    "prettier": "^2.8.2",
+    "react": ">=16.8",
+    "typescript": "^4.5.4"
+  },
+  "peerDependenciesMeta": {
     "typescript": {
-      "@typescript-eslint/parser": "^5.52.0",
-      "@typescript-eslint/eslint-plugin": "^5.52.0",
-      "eslint-plugin-deprecation": "^1.3.3"
+      "optional": true
     },
     "react": {
-      "eslint-plugin-react": "^7.32.2",
-      "eslint-plugin-react-hooks": "^4.6.0"
-    },
+      "optional": true
+    }
+  },
+  "optionals": {
     "scss": {
       "stylelint": "^15.1.0",
       "stylelint-config-recommended-scss": "^9.0.1",
@@ -50,30 +59,7 @@
   "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@hugsmidjan/hxmstyle": "github:hugsmidjan/hxmstyle#canary",
-    "eslint": "^8.34.0",
-    "eslint-config-prettier": "^8.6.0",
-    "eslint-plugin-destructure-depth": "^1.0.3",
-    "eslint-plugin-destructuring": "^2.2.1",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-simple-import-sort": "^10.0.0",
-    "eslint-plugin-total-functions": "^6.0.0",
-    "eslint-plugin-unused-imports": "^2.0.0",
-    "prettier": "^2.8.4"
-  },
-  "hxmstyle": {
-    "options": {},
-    "dependenciesAdded": [
-      "eslint",
-      "eslint-config-prettier",
-      "eslint-plugin-destructure-depth",
-      "eslint-plugin-destructuring",
-      "eslint-plugin-import",
-      "eslint-plugin-prettier",
-      "eslint-plugin-simple-import-sort",
-      "eslint-plugin-total-functions",
-      "eslint-plugin-unused-imports",
-      "prettier"
-    ]
+    "eslint": "^8.35.0",
+    "prettier": "^2.8.2"
   }
 }

--- a/starters/eslintrc.js
+++ b/starters/eslintrc.js
@@ -1,8 +1,9 @@
 module.exports = require('@hugsmidjan/hxmstyle')({
   // Place your project-specific additions or overrides here
   // using standard ESLint config syntax...
-
-  parserOptions: {
-    // ecmaVersion: 9, // fantasy
+  env: {
+    node: true,
+    browser: true,
+    es2020: true,
   },
 });

--- a/starters/eslintrc.js
+++ b/starters/eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = require('@hugsmidjan/hxmstyle')({
   // Place your project-specific additions or overrides here
   // using standard ESLint config syntax...
+
+  // extendsFirst: [], // extended BEFORE the hxmstyle rules
+  // extends: [], // added after the hxmstyle rules
   env: {
     node: true,
     browser: true,


### PR DESCRIPTION
Commit history tells the story, but the big change here is 2482750

> `@rushstack/eslint-patch/modern-module-resolution` allows us to
> declare all the eslint plugins as dependencies of this config module
> and stop manually installing them at the consuming project root.
> 
> We use the opportunity to further minimize the noise in package.json
> by only injecting the pkg.hxmstyle property when it contains
> relevant/useful information.

@Valur You can test this via `npx @hugsmidjan/hxmstyle@7.0.0-canary`

**BTW,** the new version does NOT remove plugin dependencies installed by older versions of hxmstyle, so If you want to see this working in its full glory, you should try this on a new/cleaned/un-hxmstyled repo.