### PR TITLE
Tweaking `simple-import-sort` groupings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - feat: define `^~/` and `^@/` as separate import groups
   - feat: group `*.styles` imports together with `*.s?css`
   - feat: Add `^views/`, ``libs?/` and `^api/` to locally aliased folder list
+  - fix: Support optional file extensions on css/styles import paths
 
 ## 8.0.0 - 8.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- Tweak import sorting:
+  - feat: define `^~/` and `^@/` as separate import groups
+  - feat: group `*.styles` imports together with `*.s?css`
+  - feat: Add `^views/`, ``libs?/` and `^api/` to locally aliased folder list
 
 ## 8.0.0 - 8.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+
+## 8.1.0
+
+_2023-07-17_
+
 - Tweak import sorting:
   - feat: Define `^~/` and `^@/` as separate import groups
   - feat: Group `*.styles` imports together with `*.s?css`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 - ... <!-- Add new lines here. -->
 - Tweak import sorting:
-  - feat: define `^~/` and `^@/` as separate import groups
-  - feat: group `*.styles` imports together with `*.s?css`
+  - feat: Define `^~/` and `^@/` as separate import groups
+  - feat: Group `*.styles` imports together with `*.s?css`
   - feat: Add `^views/`, ``libs?/` and `^api/` to locally aliased folder list
   - fix: Support optional file extensions on css/styles import paths
+  - feat: Place css/styles imports at the bottom
 
 ## 8.0.0 - 8.0.1
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Consider adding an npm script similar to this one to your project's
 
 ```json
     "scripts": {
-        "format": "eslint --fix  \"*.{js,ts,tsx}\" \"_src/**/*.{js,ts,tsx}\"  &&  prettier --write \"*.md\" \"*.json\"",
+        "format": "eslint --fix  \"*.{js,ts,tsx}\" \"_src/**/*.{js,ts,tsx}\"  &&  prettier --write \"*.{md,json,yml}\" \"src/**/*.{md,json,yml}\"",
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ _after_ the `hxmstyle` rules.
 However, in some cases you may want to set them to a lower priority by adding
 them in via the `extendsFirst` array.
 
-## Removing plugins
+## Removing (stylelint) plugins
 
 The hxmstyle core plugins **can not be changed** without breaking hxmstyle. If
 your project can't use the core plugins, then don't use hxmstyle.
@@ -97,7 +97,7 @@ might have installed yourself for some reason.)
 
 However, `packgage.json` always contains an updated list of
 `hxmstyle.dependencies` that you can consult when tidying up your
-devDependencies.
+`stylelint-*` devDependencies.
 
 ## Example npm scripts
 

--- a/bin/installer.js
+++ b/bin/installer.js
@@ -248,7 +248,7 @@ if (!projectPkg.scripts || !projectPkg.scripts.format) {
         jsExts +
         '\\" \\"_src/**/*.' +
         jsExts +
-        '\\"  &&  prettier --write  \\"*.md\\" \\"*.json\\""',
+        '\\"  &&  prettier --write  \\"*.{md,json,yml}\\" \\"src/**/*.{md,json,yml}\\""',
       '    },',
       '',
       'More info: https://github.com/hugsmidjan/hxmstyle/blob/master/README.md#example-npm-scripts',

--- a/configs/core.js
+++ b/configs/core.js
@@ -128,14 +128,16 @@ module.exports = {
           // Packages. `react` related packages come first.
           ['^react', '^@?\\w'],
           // Internal packages.
-          ['^(components|containers)(/.*|$)'],
-          ['^(utils|apis|hocs|hooks|pages|store|theme|types)(/.*|$)'],
+          ['^@/'],
+          ['^~/'],
+          ['^(?:components|containers)(?:/.*|$)'],
+          ['^(?:utils|apis?|hocs|hooks|pages|views|libs?|store|theme|types)(?:/.*|$)'],
           // Parent imports. Put `..` last.
           ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
           // Other relative imports. Put same-folder imports and `.` last.
           ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
           // Style imports.
-          ['^.+\\.s?css$'],
+          ['^.+\\.(?:s?css|styles)$'],
         ],
       },
     ],

--- a/configs/core.js
+++ b/configs/core.js
@@ -136,8 +136,8 @@ module.exports = {
           ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
           // Other relative imports. Put same-folder imports and `.` last.
           ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
-          // Style imports.
-          ['^.+\\.(?:s?css|styles)$'],
+          // Style imports. (with optional .js/.mjs/.cjs file-extension)
+          ['^.+\\.(?:s?css|styles)(?:\\.[mc]?js)?$'],
         ],
       },
     ],

--- a/configs/core.js
+++ b/configs/core.js
@@ -132,6 +132,8 @@ module.exports = {
           ['^~/'],
           ['^(?:components|containers)(?:/.*|$)'],
           ['^(?:utils|apis?|hocs|hooks|pages|views|libs?|store|theme|types)(?:/.*|$)'],
+          // Anything not matched in another group.
+          ["^"],
           // Parent imports. Put `..` last.
           ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
           // Other relative imports. Put same-folder imports and `.` last.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hugsmidjan/hxmstyle",
   "description": "One annoying style to rule them all...",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "main": "index.js",
   "bin": {
     "hxmstyle": "bin/installer.js"


### PR DESCRIPTION
Tweaking import sorting ... and some doc fixes.

**Changelog:**
- Tweak import sorting:
  - feat: define `^~/` and `^@/` as separate import groups (`^@/` coming first)
  - feat: group `*.styles` imports together with `*.s?css`
  - feat: Add `^views/`, `^libs?/` and `^api/` to locally aliased folder list
  - fix: Support optional file extensions on css/styles import paths
  - feat: Place css/styles imports at the bottom

Additionally: More graceful placement of the "remainders/discard" group, above the relative ../ ./ import groups.

I'd then like to release this as v8.1.0