### PR TITLE
Canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- feat: Warn on `@typescript-eslint/no-unnecessary-type-assertion`
 - feat: Disable `@typescript-eslint/no-non-null-assertion` — but warn about
   confusing uses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- feat: Disable `@typescript-eslint/no-non-null-assertion` — but warn about
+  confusing uses.
 
 ## 8.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+
+## 8.2.0
+
+_2023-08-02_
+
 - feat: Warn on `@typescript-eslint/no-unnecessary-type-assertion`
 - feat: Disable `@typescript-eslint/no-non-null-assertion` — but warn about
   confusing uses.
-
+- feat: Add `^prismic/`, `^payload/` and `^i18n/` to locally aliased folder list
+  
 ## 8.1.0
 
 _2023-07-17_
@@ -14,7 +20,7 @@ _2023-07-17_
 - Tweak import sorting:
   - feat: Define `^~/` and `^@/` as separate import groups
   - feat: Group `*.styles` imports together with `*.s?css`
-  - feat: Add `^views/`, ``libs?/` and `^api/` to locally aliased folder list
+  - feat: Add `^views/`, `^libs?/` and `^api/` to locally aliased folder list
   - fix: Support optional file extensions on css/styles import paths
   - feat: Place css/styles imports at the bottom
 

--- a/configs/core.js
+++ b/configs/core.js
@@ -130,8 +130,9 @@ module.exports = {
           // Internal packages.
           ['^@/'],
           ['^~/'],
+          ['^(?:prismic|payload)(?:/.*|$)'],
           ['^(?:components|containers)(?:/.*|$)'],
-          ['^(?:utils|apis?|hocs|hooks|pages|views|libs?|store|theme|types)(?:/.*|$)'],
+          ['^(?:utils|apis?|hocs|hooks|i18n|pages|views|libs?|store|theme|types)(?:/.*|$)'],
           // Anything not matched in another group.
           ["^"],
           // Parent imports. Put `..` last.

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -20,6 +20,9 @@ module.exports = {
       },
       plugins: ['deprecation', 'total-functions'],
       rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-confusing-non-null-assertion': 'warn',
+
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/interface-name-prefix': 'off', // 'never' | 'always // 'never' seems like a weird default

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -22,6 +22,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-confusing-non-null-assertion': 'warn',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
 
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/camelcase': 'off',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hugsmidjan/hxmstyle",
   "description": "One annoying style to rule them all...",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "main": "index.js",
   "bin": {
     "hxmstyle": "bin/installer.js"


### PR DESCRIPTION
Tweaking how it handles type assertions. Nothing too radical I think.

#### feat: Disable @typescript-eslint/no-non-null-assertion

…but warn about confusing uses.

Rationale:  
When using `noUncheckedIndexedAccess`, the compiler will repeatedly warn you about array access, and a lot of the time adding `!` to the end of the expression is the most sensible + ergonomical way to fix it.

This is also about consistency. The non-null assertion operator is just a sugar/shorthand for `as Exclude<T, null | undefined>`[^1], and such expressions do not trigger warnings.

[^1]: or more succinctly: `T | {}`  😁 

#### feat: Warn on @typescript-eslint/no-unnecessary-type-assertion

Rationale:  
This rule is akin to the `@typescript-eslint/no-unnecessary-condition` but completely non-breaking.
