### PR TITLE
feat: Raise `@typescript-eslint/no-explicit-any` back to `error` level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- feat: Raise `@typescript-eslint/no-explicit-any` back to `error` level
 - fix: `prefer-const` switches to "error" in TS files (+ allow destructuring)
 
 ## 8.2.0

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -72,7 +72,7 @@ module.exports = {
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': 'warn',
         '@typescript-eslint/no-explicit-any': [
-          'warn',
+          'error',
           { fixToUnknown: false, ignoreRestArgs: true },
         ],
         '@typescript-eslint/indent': ['error', 2],


### PR DESCRIPTION
Explicitly using `any` (outside `...rest:args[]` function arguments) is a **massive** red flag for a codebase, in vast majority of cases.

A good linting config ought to treat it as "error" by default, and force developers to make informed decisions — either to improve the type, or at least be explicit about this being an exception by adding a `eslint-disable` directive.

Wilfully using `any` should always "hurt", at least a little bit.  
(…because you're usually trading short-term gain for longer term pain/costs for your co-workers and clients.)