### PR TITLE
Misc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming...
 
 - ... <!-- Add new lines here. -->
+- feat: Enable `react/jsx-curly-brace-presence` with `'never'`
 
 ## 8.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ... <!-- Add new lines here. -->
 - feat: Enable `react/jsx-curly-brace-presence` with `'never'`
+- fix: Relax `@typescript-eslint/no-empty-interface` to `warn` level
 
 ## 8.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ... <!-- Add new lines here. -->
 - feat: Enable `react/jsx-curly-brace-presence` with `'never'`
 - fix: Relax `@typescript-eslint/no-empty-interface` to `warn` level
+- fix: Relax `destructuring/in-params` to `warn` level
 
 ## 8.3.0
 

--- a/configs/core.js
+++ b/configs/core.js
@@ -115,8 +115,8 @@ module.exports = {
 
     // Rules for "eslint-plugin-destructuring":
     // 'destructuring/no-rename': 'error',
-    'destructuring/in-params': ['error', {'max-params': 2 }], // Allow {items.map(({ value, label}, i) => <li key={i}/* ... */</li>)}
-    'destructuring/in-methods-params': 'error',
+    'destructuring/in-params': ['warn', {'max-params': 2 }], // Allow {items.map(({ value, label}, i) => <li key={i}/* ... */</li>)}
+    'destructuring/in-methods-params': 'warn',
     // See also: https://mysticatea.github.io/eslint-plugin-es/rules/no-destructuring.html
 
     // Rules for "eslint-plugin-unused-imports":

--- a/configs/core.js
+++ b/configs/core.js
@@ -67,6 +67,7 @@ module.exports = {
     // If you really, really NEED `console.log()` without warnings,
     // either do `window.console.log();` or `global.console.log();`,
     // or insert a `/*eslint no-console: false */` marker into your file.
+    // (Intentionally omitting: 'debug' as it aliases 'log')
     'no-console': ['warn', { allow: ['warn', 'error', 'info', 'group', 'groupCollapsed', 'groupEnd'] }],
     'no-div-regex': 'error',
     'no-label-var': 'error',

--- a/configs/react.js
+++ b/configs/react.js
@@ -20,5 +20,9 @@ module.exports = {
     // https://www.npmjs.com/package/eslint-plugin-react-hooks
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'react/jsx-curly-brace-presence': [
+      'warn',
+      { props: 'never', children: 'never', propElementValues: 'always' },
+    ],
   },
 };

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -27,6 +27,7 @@ module.exports = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/interface-name-prefix': 'off', // 'never' | 'always // 'never' seems like a weird default
+        '@typescript-eslint/no-empty-interface': 'warn',
         '@typescript-eslint/array-type': ['warn', { default: 'generic' }], // 'array' -> `T[]` ;  'generic' -> `Array<T>`
         '@typescript-eslint/no-extraneous-class': 'warn',
         '@typescript-eslint/no-useless-constructor': 'warn',


### PR DESCRIPTION
Rationale:

- [feat: Enable react/jsx-curly-brace-presence with 'never'](https://github.com/hugsmidjan/hxmstyle/pull/19/commits/f576a966d0596e6fac9cc33f5658a0c5db4ca2c2) (I tried it, it's nice!)  
It's an auto-fixable rule that could have been part of prettier, but they decided it was too complicated/nuanced, and thus best delegated to the official React eslint plugin: https://github.com/prettier/prettier/issues/3303
- [fix: Relax @typescript-eslint/no-empty-interface to warn level](https://github.com/hugsmidjan/hxmstyle/pull/19/commits/73db5d8625fc348766802ab94078eaaf9d025cfd)  
The recommended setting "error"s, which makes no senes when `type Foo = {}` is merely a "warn"
- [fix: Relax destructuring/in-params to warn level](https://github.com/hugsmidjan/hxmstyle/pull/19/commits/429db6b2d0f1e057b94a45160885db17db28aa55)  
Destructuring in parameters gets very hairy, very quickly, but should probably not be a cause for stopping pushes/builds